### PR TITLE
Fix etal() truncating hyphenated author names

### DIFF
--- a/twXiv_format.py
+++ b/twXiv_format.py
@@ -141,8 +141,10 @@ def surnames(orig):
 
 
 def etal(orig):
-    first_author = re.search(r"[\w|.| ]+,", orig)
-    return first_author.group() + " et al."
+    names = orig.split(",")
+    if len(names) > 1:
+        return names[0].strip() + ", et al."
+    return orig
 
 
 # separate a text by weighted lengths <=lim


### PR DESCRIPTION
The regex [\w|.| ]+, in etal() did not include hyphens, Replace the fragile regex with a simple comma split, which matches the comma-separated format produced by arXiv_feed_parser.

https://claude.ai/code/session_01Ee9NXs88a5J8VtJjoKYxD2