### PR TITLE
Fix leading colon when authors field is empty

### DIFF
--- a/twXiv_format.py
+++ b/twXiv_format.py
@@ -135,7 +135,7 @@ def noparen(test_str):
 
 def surnames(orig):
     names = orig.split(",")
-    sr_names = [HumanName(one).last for one in names]
+    sr_names = [HumanName(one).last or one.strip() for one in names]
     separator = ", "
     return separator.join(sr_names)
 

--- a/twXiv_post.py
+++ b/twXiv_post.py
@@ -281,9 +281,11 @@ def newsubmissions(logfiles, cat, caption, api, update_limited, entries, pt_mode
     if half == 0:
         for each in entries:
             arxiv_id = each["id"]
+            authors_prefix = (
+                each["authors"] + ": " if each["authors"] else ""
+            )
             article_text = (
-                each["authors"]
-                + ": "
+                authors_prefix
                 + each["title"]
                 + " "
                 + each["abs_url"]
@@ -298,8 +300,11 @@ def newsubmissions(logfiles, cat, caption, api, update_limited, entries, pt_mode
     else:
         for each in entries:
             pre_arxiv_id = each["id"]
+            authors_prefix = (
+                each["authors"] + ": " if each["authors"] else ""
+            )
             pre_article_text = (
-                each["authors"] + ": " + each["title"] + " " + each["abs_url"]
+                authors_prefix + each["title"] + " " + each["abs_url"]
             )
             if int(post_counter % 2) == 1:
                 arxiv_id = pre_arxiv_id


### PR DESCRIPTION
When authors() cannot fit any truncated form within the character budget, it returns "". The tweet composition unconditionally prepended ": ", producing tweets like ": Title here...". Now only add the ": " separator when authors is non-empty.

Also make surnames() fall back to the original name when HumanName returns an empty last name (e.g. for single-word names).

https://claude.ai/code/session_01Ee9NXs88a5J8VtJjoKYxD2