### PR TITLE
Add multi-paper posting modes (1, 2, or 3 papers per post)

### DIFF
--- a/twXiv_post.py
+++ b/twXiv_post.py
@@ -295,7 +295,7 @@ def newsubmissions(logfiles, cat, caption, api, update_limited, entries, pt_mode
         article_text = ""
         for each in entries:
             pre_arxiv_id = each["id"]
-            pre_article_text = each["title"] + " arXiv:" + pre_arxiv_id
+            pre_article_text = each["title"] + "\narXiv:" + pre_arxiv_id
             pos = post_counter % 2
             if pos == 1:
                 arxiv_id = pre_arxiv_id
@@ -318,7 +318,7 @@ def newsubmissions(logfiles, cat, caption, api, update_limited, entries, pt_mode
         article_text = ""
         for each in entries:
             pre_arxiv_id = each["id"]
-            pre_article_text = each["title"] + " arXiv:" + pre_arxiv_id
+            pre_article_text = each["title"] + "\narXiv:" + pre_arxiv_id
             pos = post_counter % 3
             if pos == 1:
                 arxiv_id = pre_arxiv_id


### PR DESCRIPTION
## Summary

- Adds `num_papers_per_post` global constant in `twXiv_variables.py` (set to 1, 2, or 3) to control how many papers appear in each post
- Adds `summary_posting` global (0 or 1) to control whether the introductory summary post is sent
- For modes 2 and 3, each paper entry is formatted as:
  ```
  title
  arXiv:XXXX.YYYY
  ```
- `num_papers_per_post = 1`: original format (authors + title + abs/pdf/html URLs), up to 15 papers
- `num_papers_per_post = 2`: two papers per post, up to 30 papers
- `num_papers_per_post = 3`: three papers per post, up to 45 papers
- Paper cap enforced by the existing `rate_limited(post_updates, a_day)` decorator (16 posts/day; 15 for papers when summary is on)
- Renames the old `half` parameter to `num_papers_per_post` throughout for clarity

## Test plan

- [ ] Verify `num_papers_per_post = 1` produces the original single-paper format with authors and URLs
- [ ] Verify `num_papers_per_post = 2` produces paired posts with `title\narXiv:XXXX.YYYY` format
- [ ] Verify `num_papers_per_post = 3` produces triple posts with `title\narXiv:XXXX.YYYY` format
- [ ] Verify `summary_posting = 0` suppresses the intro post for all modes
- [ ] Verify `summary_posting = 1` sends the intro post for all modes

https://claude.ai/code/session_01MEfqUTdE1Kjg42bRkFjLgM

---
_Generated by [Claude Code](https://claude.ai/code/session_01MEfqUTdE1Kjg42bRkFjLgM)_